### PR TITLE
fix(api): add missing allowed origins for newsletter endpoint

### DIFF
--- a/src/app/api/(external)/newsletter/route.ts
+++ b/src/app/api/(external)/newsletter/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 const ALLOWED_ORIGINS = [
+	"https://shop.obana.africa",
+	"https://staging.shop.obana.africa",
 	"https://www.obana.africa",
 	"https://obana.africa",
 	"http://localhost:3000",


### PR DESCRIPTION
The shop and staging shop domains were missing from the CORS allowed origins list, which could prevent legitimate requests from these domains. This adds both production and staging shop domains to the ALLOWED_ORIGINS array.